### PR TITLE
Logical plan serialization: function serialization rework - remove function_set_key and bind based on argument types instead

### DIFF
--- a/extension/icu/icu-strptime.cpp
+++ b/extension/icu/icu-strptime.cpp
@@ -141,7 +141,7 @@ struct ICUStrptime : public ICUDateFunc {
 		}
 
 		// Tail patch the old binder
-		auto bound_function = func.functions.GetFunction(best_function);
+		auto bound_function = func.functions.GetFunctionByOffset(best_function);
 		bind = bound_function.bind;
 		bound_function.bind = StrpTimeBindFunction;
 	}

--- a/src/catalog/catalog_entry/schema_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/schema_catalog_entry.cpp
@@ -223,7 +223,7 @@ CatalogEntry *SchemaCatalogEntry::AddFunction(ClientContext &context, CreateFunc
 		auto scalar_info = (CreateScalarFunctionInfo *)info;
 		auto &scalars = *(ScalarFunctionCatalogEntry *)entry;
 		for (const auto &scalar : scalars.functions.functions) {
-			scalar_info->functions.AddFunction(scalar.second);
+			scalar_info->functions.AddFunction(scalar);
 		}
 		break;
 	}
@@ -231,7 +231,7 @@ CatalogEntry *SchemaCatalogEntry::AddFunction(ClientContext &context, CreateFunc
 		auto agg_info = (CreateAggregateFunctionInfo *)info;
 		auto &aggs = *(AggregateFunctionCatalogEntry *)entry;
 		for (const auto &agg : aggs.functions.functions) {
-			agg_info->functions.AddFunction(agg.second);
+			agg_info->functions.AddFunction(agg);
 		}
 		break;
 	}

--- a/src/execution/expression_executor/execute_function.cpp
+++ b/src/execution/expression_executor/execute_function.cpp
@@ -75,6 +75,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	arguments.SetCardinality(count);
 
 	state->profiler.BeginSample();
+	D_ASSERT(expr.function.function);
 	expr.function.function(arguments, *state, result);
 	state->profiler.EndSample(count);
 

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -169,15 +169,15 @@ AggregateFunction GetAverageAggregate(PhysicalType type) {
 	}
 	case PhysicalType::INT32: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
-		        LogicalType::INTEGER, LogicalType::DOUBLE);
+		    LogicalType::INTEGER, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INT64: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
-		        LogicalType::BIGINT, LogicalType::DOUBLE);
+		    LogicalType::BIGINT, LogicalType::DOUBLE);
 	}
 	case PhysicalType::INT128: {
 		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
-		        LogicalType::HUGEINT, LogicalType::DOUBLE);
+		    LogicalType::HUGEINT, LogicalType::DOUBLE);
 	}
 	default:
 		throw InternalException("Unimplemented average aggregate");
@@ -208,7 +208,7 @@ void AvgFun::RegisterFunction(BuiltinFunctions &set) {
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64));
 	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(avg);
 
 	avg.name = "mean";

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -164,39 +164,20 @@ static unique_ptr<FunctionData> DeserializeDecimalAvg(ClientContext &context, Fi
 AggregateFunction GetAverageAggregate(PhysicalType type) {
 	switch (type) {
 	case PhysicalType::INT16: {
-		auto function = AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
+		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
 		    LogicalType::SMALLINT, LogicalType::DOUBLE);
-		function.function_set_key = 1;
-		function.serialize = SerializeDecimalAvg;
-		function.deserialize = DeserializeDecimalAvg;
-		return function;
 	}
 	case PhysicalType::INT32: {
-		auto function =
-		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
 		        LogicalType::INTEGER, LogicalType::DOUBLE);
-		function.function_set_key = 2;
-		function.serialize = SerializeDecimalAvg;
-		function.deserialize = DeserializeDecimalAvg;
-		return function;
 	}
 	case PhysicalType::INT64: {
-		auto function =
-		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
 		        LogicalType::BIGINT, LogicalType::DOUBLE);
-		function.function_set_key = 3;
-		function.serialize = SerializeDecimalAvg;
-		function.deserialize = DeserializeDecimalAvg;
-		return function;
 	}
 	case PhysicalType::INT128: {
-		auto function =
-		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
 		        LogicalType::HUGEINT, LogicalType::DOUBLE);
-		function.function_set_key = 4;
-		function.serialize = SerializeDecimalAvg;
-		function.deserialize = DeserializeDecimalAvg;
-		return function;
 	}
 	default:
 		throw InternalException("Unimplemented average aggregate");
@@ -207,6 +188,8 @@ unique_ptr<FunctionData> BindDecimalAvg(ClientContext &context, AggregateFunctio
                                         vector<unique_ptr<Expression>> &arguments) {
 	auto decimal_type = arguments[0]->return_type;
 	function = GetAverageAggregate(decimal_type.InternalType());
+	function.serialize = SerializeDecimalAvg;
+	function.deserialize = DeserializeDecimalAvg;
 	function.name = "avg";
 	function.arguments[0] = decimal_type;
 	function.return_type = LogicalType::DOUBLE;
@@ -219,15 +202,13 @@ void AvgFun::RegisterFunction(BuiltinFunctions &set) {
 
 	avg.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
 	                                  nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr,
-	                                  BindDecimalAvg),
-	                0);
-	avg.AddFunction(GetAverageAggregate(PhysicalType::INT16), 1);
-	avg.AddFunction(GetAverageAggregate(PhysicalType::INT32), 2);
-	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64), 3);
-	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128), 4);
+	                                  BindDecimalAvg));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT16));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT32));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
 	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE),
-	                5);
+	                    LogicalType::DOUBLE, LogicalType::DOUBLE));
 	set.AddFunction(avg);
 
 	avg.name = "mean";

--- a/src/function/aggregate/algebraic/avg.cpp
+++ b/src/function/aggregate/algebraic/avg.cpp
@@ -149,18 +149,6 @@ struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, Kaha
 	}
 };
 
-static void SerializeDecimalAvg(FieldWriter &writer, const FunctionData *bind_data_p,
-                                const AggregateFunction &function) {
-	D_ASSERT(bind_data_p);
-	auto bind_data = (AverageDecimalBindData *)bind_data_p;
-	writer.WriteField(bind_data->scale);
-}
-
-static unique_ptr<FunctionData> DeserializeDecimalAvg(ClientContext &context, FieldReader &reader,
-                                                      AggregateFunction &function) {
-	return make_unique<AverageDecimalBindData>(reader.ReadRequired<double>());
-}
-
 AggregateFunction GetAverageAggregate(PhysicalType type) {
 	switch (type) {
 	case PhysicalType::INT16: {
@@ -188,8 +176,6 @@ unique_ptr<FunctionData> BindDecimalAvg(ClientContext &context, AggregateFunctio
                                         vector<unique_ptr<Expression>> &arguments) {
 	auto decimal_type = arguments[0]->return_type;
 	function = GetAverageAggregate(decimal_type.InternalType());
-	function.serialize = SerializeDecimalAvg;
-	function.deserialize = DeserializeDecimalAvg;
 	function.name = "avg";
 	function.arguments[0] = decimal_type;
 	function.return_type = LogicalType::DOUBLE;

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -257,7 +257,7 @@ static AggregateFunction GetFirstFunction(const LogicalType &type) {
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB: {
 		return AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
-		                                                       FirstFunctionString<LAST>>(type, type);
+		                                                   FirstFunctionString<LAST>>(type, type);
 	}
 	case LogicalTypeId::DECIMAL: {
 		type.Verify();

--- a/src/function/aggregate/distributive/first.cpp
+++ b/src/function/aggregate/distributive/first.cpp
@@ -199,9 +199,7 @@ struct FirstVectorFunction {
 
 template <class T, bool LAST>
 static AggregateFunction GetFirstAggregateTemplated(LogicalType type) {
-	auto agg = AggregateFunction::UnaryAggregate<FirstState<T>, T, T, FirstFunction<LAST>>(type, type);
-	agg.function_set_key = (idx_t) type.id(); // FIXME ugly
-	return agg;
+	return AggregateFunction::UnaryAggregate<FirstState<T>, T, T, FirstFunction<LAST>>(type, type);
 }
 
 template <bool LAST>
@@ -258,10 +256,8 @@ static AggregateFunction GetFirstFunction(const LogicalType &type) {
 		return GetFirstAggregateTemplated<interval_t, LAST>(type);
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::BLOB: {
-		auto agg = AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
+		return AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
 		                                                       FirstFunctionString<LAST>>(type, type);
-		agg.function_set_key = (idx_t) type.id();
-		return agg;
 	}
 	case LogicalTypeId::DECIMAL: {
 		type.Verify();

--- a/src/function/aggregate/distributive/minmax.cpp
+++ b/src/function/aggregate/distributive/minmax.cpp
@@ -518,7 +518,6 @@ unique_ptr<FunctionData> BindDecimalMinMax(ClientContext &context, AggregateFunc
 		function = GetUnaryAggregate<OP>(LogicalType::HUGEINT);
 		break;
 	}
-	function.function_set_key = (idx_t)function.arguments[0].id(); // TODO this is pretty evil
 	function.name = move(name);
 	function.arguments[0] = decimal_type;
 	function.return_type = decimal_type;
@@ -540,18 +539,16 @@ static void AddMinMaxOperator(AggregateFunctionSet &set) {
 		if (type.id() == LogicalTypeId::VARCHAR || type.id() == LogicalTypeId::BLOB || type.id() == LogicalType::JSON) {
 			set.AddFunction(
 			    AggregateFunction::UnaryAggregateDestructor<MinMaxState<string_t>, string_t, string_t, OP_STRING>(
-			        type.id(), type.id()),
-			    (idx_t)type.id());
+			        type.id(), type.id()));
 		} else if (type.id() == LogicalTypeId::DECIMAL) {
 			set.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-			                                  BindDecimalMinMax<OP>),
-			                (idx_t)type.id());
+			                                  BindDecimalMinMax<OP>));
 		} else if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::MAP ||
 		           type.id() == LogicalTypeId::STRUCT) {
-			set.AddFunction(GetMinMaxFunction<OP_VECTOR, VectorMinMaxState>(type), (idx_t)type.id());
+			set.AddFunction(GetMinMaxFunction<OP_VECTOR, VectorMinMaxState>(type));
 
 		} else {
-			set.AddFunction(GetUnaryAggregate<OP>(type), (idx_t)type.id()); // TODO this is pretty evil
+			set.AddFunction(GetUnaryAggregate<OP>(type)); // TODO this is pretty evil
 		}
 	}
 }

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -179,7 +179,7 @@ void SumFun::RegisterFunction(BuiltinFunctions &set) {
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
 	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
 
 	set.AddFunction(sum);
 

--- a/src/function/aggregate/distributive/sum.cpp
+++ b/src/function/aggregate/distributive/sum.cpp
@@ -110,14 +110,12 @@ unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggreg
 			expr.function =
 			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int32_t, hugeint_t, IntegerSumOperation>(
 			        LogicalType::INTEGER, LogicalType::HUGEINT);
-			expr.function.function_set_key = 2; // TODO UUUGLY
 			expr.function.name = "sum";
 			break;
 		case PhysicalType::INT64:
 			expr.function =
 			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int64_t, hugeint_t, IntegerSumOperation>(
 			        LogicalType::BIGINT, LogicalType::HUGEINT);
-			expr.function.function_set_key = 3; // TODO UUUGLY
 			expr.function.name = "sum";
 			break;
 		default:
@@ -132,7 +130,6 @@ AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
 	case PhysicalType::INT16: {
 		auto function = AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
 		    LogicalType::SMALLINT, LogicalType::HUGEINT);
-		function.function_set_key = 1;
 		return function;
 	}
 
@@ -141,7 +138,6 @@ AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
 		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int32_t, hugeint_t, SumToHugeintOperation>(
 		        LogicalType::INTEGER, LogicalType::HUGEINT);
 		function.statistics = SumPropagateStats;
-		function.function_set_key = 2;
 		return function;
 	}
 	case PhysicalType::INT64: {
@@ -149,14 +145,12 @@ AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
 		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int64_t, hugeint_t, SumToHugeintOperation>(
 		        LogicalType::BIGINT, LogicalType::HUGEINT);
 		function.statistics = SumPropagateStats;
-		function.function_set_key = 3;
 		return function;
 	}
 	case PhysicalType::INT128: {
 		auto function =
 		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
 		        LogicalType::HUGEINT, LogicalType::HUGEINT);
-		function.function_set_key = 4;
 		return function;
 	}
 	default:
@@ -179,15 +173,13 @@ void SumFun::RegisterFunction(BuiltinFunctions &set) {
 	// decimal
 	sum.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
 	                                  nullptr, nullptr, FunctionNullHandling::DEFAULT_NULL_HANDLING, nullptr,
-	                                  BindDecimalSum),
-	                0);
+	                                  BindDecimalSum));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT16));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
 	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
 	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
-	                    LogicalType::DOUBLE, LogicalType::DOUBLE),
-	                5);
+	                    LogicalType::DOUBLE, LogicalType::DOUBLE));
 
 	set.AddFunction(sum);
 

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -53,8 +53,7 @@ Function::~Function() {
 }
 
 SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType varargs_p)
-    : Function(move(name_p)), arguments(move(arguments_p)),
-      varargs(move(varargs_p)) {
+    : Function(move(name_p)), arguments(move(arguments_p)), varargs(move(varargs_p)) {
 }
 
 SimpleFunction::~SimpleFunction() {
@@ -287,7 +286,7 @@ static vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<
 	idx_t best_function = DConstants::INVALID_INDEX;
 	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
 	vector<idx_t> candidate_functions;
-	for(idx_t f_idx = 0; f_idx < functions.functions.size(); f_idx++) {
+	for (idx_t f_idx = 0; f_idx < functions.functions.size(); f_idx++) {
 		auto &func = functions.functions[f_idx];
 		// check the arguments of the function
 		int64_t cost = BindFunctionCost(func, arguments);
@@ -342,8 +341,8 @@ static idx_t MultipleCandidateException(const string &name, FunctionSet<T> &func
 }
 
 template <class T>
-static idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &functions, const vector<LogicalType> &arguments,
-                                       string &error) {
+static idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &functions,
+                                       const vector<LogicalType> &arguments, string &error) {
 	auto candidate_functions = BindFunctionsFromArguments<T>(name, functions, arguments, error);
 	if (candidate_functions.empty()) {
 		// no candidates

--- a/src/function/function.cpp
+++ b/src/function/function.cpp
@@ -53,7 +53,7 @@ Function::~Function() {
 }
 
 SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType varargs_p)
-    : Function(move(name_p)), function_set_key(DConstants::INVALID_INDEX), arguments(move(arguments_p)),
+    : Function(move(name_p)), arguments(move(arguments_p)),
       varargs(move(varargs_p)) {
 }
 
@@ -226,7 +226,7 @@ string Function::CallToString(const string &name, const vector<LogicalType> &arg
 	return StringUtil::Format("%s(%s)", name, StringUtil::Join(input_arguments, ", "));
 }
 
-static int64_t BindVarArgsFunctionCost(const SimpleFunction &func, vector<LogicalType> &arguments) {
+static int64_t BindVarArgsFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments) {
 	if (arguments.size() < func.arguments.size()) {
 		// not enough arguments to fulfill the non-vararg part of the function
 		return -1;
@@ -250,7 +250,7 @@ static int64_t BindVarArgsFunctionCost(const SimpleFunction &func, vector<Logica
 	return cost;
 }
 
-static int64_t BindFunctionCost(const SimpleFunction &func, vector<LogicalType> &arguments) {
+static int64_t BindFunctionCost(const SimpleFunction &func, const vector<LogicalType> &arguments) {
 	if (func.HasVarArgs()) {
 		// special case varargs function
 		return BindVarArgsFunctionCost(func, arguments);
@@ -283,13 +283,12 @@ static int64_t BindFunctionCost(const SimpleFunction &func, vector<LogicalType> 
 
 template <class T>
 static vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<T> &functions,
-                                                vector<LogicalType> &arguments, string &error) {
+                                                const vector<LogicalType> &arguments, string &error) {
 	idx_t best_function = DConstants::INVALID_INDEX;
 	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
 	vector<idx_t> candidate_functions;
-	for (const auto &entry : functions.functions) {
-		auto f_idx = entry.first;
-		auto &func = entry.second;
+	for(idx_t f_idx = 0; f_idx < functions.functions.size(); f_idx++) {
+		auto &func = functions.functions[f_idx];
 		// check the arguments of the function
 		int64_t cost = BindFunctionCost(func, arguments);
 		if (cost < 0) {
@@ -312,7 +311,7 @@ static vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<
 		string call_str = Function::CallToString(name, arguments);
 		string candidate_str = "";
 		for (auto &f : functions.functions) {
-			candidate_str += "\t" + f.second.ToString() + "\n";
+			candidate_str += "\t" + f.ToString() + "\n";
 		}
 		error = StringUtil::Format("No function matches the given name and argument types '%s'. You might need to add "
 		                           "explicit type casts.\n\tCandidate functions:\n%s",
@@ -325,7 +324,7 @@ static vector<idx_t> BindFunctionsFromArguments(const string &name, FunctionSet<
 
 template <class T>
 static idx_t MultipleCandidateException(const string &name, FunctionSet<T> &functions,
-                                        vector<idx_t> &candidate_functions, vector<LogicalType> &arguments,
+                                        vector<idx_t> &candidate_functions, const vector<LogicalType> &arguments,
                                         string &error) {
 	D_ASSERT(functions.functions.size() > 1);
 	// there are multiple possible function definitions
@@ -333,7 +332,7 @@ static idx_t MultipleCandidateException(const string &name, FunctionSet<T> &func
 	string call_str = Function::CallToString(name, arguments);
 	string candidate_str = "";
 	for (auto &conf : candidate_functions) {
-		T f = functions.GetFunction(conf);
+		T f = functions.GetFunctionByOffset(conf);
 		candidate_str += "\t" + f.ToString() + "\n";
 	}
 	error = StringUtil::Format("Could not choose a best candidate function for the function call \"%s\". In order to "
@@ -343,7 +342,7 @@ static idx_t MultipleCandidateException(const string &name, FunctionSet<T> &func
 }
 
 template <class T>
-static idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &functions, vector<LogicalType> &arguments,
+static idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &functions, const vector<LogicalType> &arguments,
                                        string &error) {
 	auto candidate_functions = BindFunctionsFromArguments<T>(name, functions, arguments, error);
 	if (candidate_functions.empty()) {
@@ -366,17 +365,17 @@ static idx_t BindFunctionFromArguments(const string &name, FunctionSet<T> &funct
 	return candidate_functions[0];
 }
 
-idx_t Function::BindFunction(const string &name, ScalarFunctionSet &functions, vector<LogicalType> &arguments,
+idx_t Function::BindFunction(const string &name, ScalarFunctionSet &functions, const vector<LogicalType> &arguments,
                              string &error) {
 	return BindFunctionFromArguments(name, functions, arguments, error);
 }
 
-idx_t Function::BindFunction(const string &name, AggregateFunctionSet &functions, vector<LogicalType> &arguments,
+idx_t Function::BindFunction(const string &name, AggregateFunctionSet &functions, const vector<LogicalType> &arguments,
                              string &error) {
 	return BindFunctionFromArguments(name, functions, arguments, error);
 }
 
-idx_t Function::BindFunction(const string &name, TableFunctionSet &functions, vector<LogicalType> &arguments,
+idx_t Function::BindFunction(const string &name, TableFunctionSet &functions, const vector<LogicalType> &arguments,
                              string &error) {
 	return BindFunctionFromArguments(name, functions, arguments, error);
 }
@@ -390,7 +389,7 @@ idx_t Function::BindFunction(const string &name, PragmaFunctionSet &functions, P
 	if (entry == DConstants::INVALID_INDEX) {
 		throw BinderException(error);
 	}
-	auto candidate_function = functions.GetFunction(entry);
+	auto candidate_function = functions.GetFunctionByOffset(entry);
 	// cast the input parameters
 	for (idx_t i = 0; i < info.parameters.size(); i++) {
 		auto target_type =
@@ -481,7 +480,7 @@ unique_ptr<Expression> ScalarFunction::BindScalarFunction(ClientContext &context
 	}
 
 	// found a matching function!
-	auto bound_function = func.functions.GetFunction(best_function);
+	auto bound_function = func.functions.GetFunctionByOffset(best_function);
 
 	if (bound_function.null_handling == FunctionNullHandling::DEFAULT_NULL_HANDLING) {
 		for (auto &child : children) {
@@ -506,10 +505,6 @@ unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientCon
 
 	// now create the function
 	auto return_type = bound_function.return_type;
-	// check if we messed up the function index
-	if (bound_function.function_set_key == DConstants::INVALID_INDEX) {
-		throw BinderException("Function %s bound with invalid set key", bound_function.name);
-	}
 	return make_unique<BoundFunctionExpression>(move(return_type), move(bound_function), move(children),
 	                                            move(bind_info), is_operator);
 }

--- a/src/function/scalar/list/list_aggregates.cpp
+++ b/src/function/scalar/list/list_aggregates.cpp
@@ -376,8 +376,7 @@ static unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, Scala
 	}
 
 	// found a matching function, bind it as an aggregate
-	auto best_function = func->functions.GetFunction(best_function_idx);
-
+	auto best_function = func->functions.GetFunctionByOffset(best_function_idx);
 	if (IS_AGGR) {
 		return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, list_child_type, best_function);
 	}

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -550,16 +550,13 @@ static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, F
 
 ScalarFunction SubtractFun::GetFunction(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::INTERVAL) {
-		return
-		    ScalarFunction("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
+		return ScalarFunction("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
 	} else if (type.id() == LogicalTypeId::DECIMAL) {
-		return
-		    ScalarFunction("-", {type}, type, nullptr, DecimalNegateBind, nullptr, NegateBindStatistics);
+		return ScalarFunction("-", {type}, type, nullptr, DecimalNegateBind, nullptr, NegateBindStatistics);
 	} else {
 		D_ASSERT(type.IsNumeric());
-		return ScalarFunction("-", {type}, type,
-		                                       ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type), nullptr,
-		                                       nullptr, NegateBindStatistics);
+		return ScalarFunction("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type), nullptr,
+		                      nullptr, NegateBindStatistics);
 	}
 }
 
@@ -579,52 +576,46 @@ ScalarFunction SubtractFun::GetFunction(const LogicalType &left_type, const Logi
 			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
 
 		} else {
-			return
-			    ScalarFunction("-", {left_type, right_type}, left_type,
-			                   GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
+			return ScalarFunction("-", {left_type, right_type}, left_type,
+			                      GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
 		}
 	}
 
 	switch (left_type.id()) {
 	case LogicalTypeId::DATE:
 		if (right_type.id() == LogicalTypeId::DATE) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::BIGINT,
-			                   ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::BIGINT,
+			                      ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
 
 		} else if (right_type.id() == LogicalTypeId::INTEGER) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
-			                   ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
-			                   ScalarFunction::BinaryFunction<date_t, interval_t, date_t, SubtractOperator>);
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, interval_t, date_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::TIMESTAMP:
 		if (right_type.id() == LogicalTypeId::TIMESTAMP) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
-			                   ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
+			return ScalarFunction(
+			    "-", {left_type, right_type}, LogicalType::INTERVAL,
+			    ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::TIMESTAMP,
-			                   ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
+			return ScalarFunction(
+			    "-", {left_type, right_type}, LogicalType::TIMESTAMP,
+			    ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::INTERVAL:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
-			                   ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
+			                      ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::TIME:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return
-			    ScalarFunction("-", {left_type, right_type}, LogicalType::TIME,
-			                   ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>);
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::TIME,
+			                      ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>);
 		}
 		break;
 	default:

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -276,7 +276,9 @@ unique_ptr<FunctionData> DeserializeDecimalArithmetic(ClientContext &context, Fi
 	bound_function.return_type = return_type;
 	bound_function.arguments = arguments;
 
-	return nullptr;
+	auto bind_data = make_unique<DecimalArithmeticBindData>();
+	bind_data->check_overflow = check_overflow;
+	return move(bind_data);
 }
 
 unique_ptr<FunctionData> NopDecimalBind(ClientContext &context, ScalarFunction &bound_function,

--- a/src/function/scalar/operators/arithmetic.cpp
+++ b/src/function/scalar/operators/arithmetic.cpp
@@ -548,29 +548,18 @@ static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, F
 	return move(stats);
 }
 
-// TODO somewhat ugly
-static ScalarFunction KeyFromArguments(ScalarFunction function) {
-	idx_t key = 0;
-	for (auto &arg : function.arguments) {
-		key += (idx_t)arg.id();
-		key *= 1000;
-	}
-	function.function_set_key = key;
-	return function;
-}
-
 ScalarFunction SubtractFun::GetFunction(const LogicalType &type) {
 	if (type.id() == LogicalTypeId::INTERVAL) {
-		return KeyFromArguments(
-		    ScalarFunction("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>));
+		return
+		    ScalarFunction("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
 	} else if (type.id() == LogicalTypeId::DECIMAL) {
-		return KeyFromArguments(
-		    ScalarFunction("-", {type}, type, nullptr, DecimalNegateBind, nullptr, NegateBindStatistics));
+		return
+		    ScalarFunction("-", {type}, type, nullptr, DecimalNegateBind, nullptr, NegateBindStatistics);
 	} else {
 		D_ASSERT(type.IsNumeric());
-		return KeyFromArguments(ScalarFunction("-", {type}, type,
+		return ScalarFunction("-", {type}, type,
 		                                       ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type), nullptr,
-		                                       nullptr, NegateBindStatistics));
+		                                       nullptr, NegateBindStatistics);
 	}
 }
 
@@ -582,60 +571,60 @@ ScalarFunction SubtractFun::GetFunction(const LogicalType &left_type, const Logi
 			                   BindDecimalAddSubtract<SubtractOperator, DecimalSubtractOverflowCheck, true>);
 			function.serialize = SerializeDecimalArithmetic;
 			function.deserialize = DeserializeDecimalArithmetic<SubtractOperator, DecimalSubtractOverflowCheck>;
-			return KeyFromArguments(function);
+			return function;
 		} else if (left_type.IsIntegral() && left_type.id() != LogicalTypeId::HUGEINT) {
-			return KeyFromArguments(ScalarFunction(
+			return ScalarFunction(
 			    "-", {left_type, right_type}, left_type,
 			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), nullptr, nullptr,
-			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>));
+			    PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
 
 		} else {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, left_type,
-			                   GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType())));
+			                   GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
 		}
 	}
 
 	switch (left_type.id()) {
 	case LogicalTypeId::DATE:
 		if (right_type.id() == LogicalTypeId::DATE) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::BIGINT,
-			                   ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
 
 		} else if (right_type.id() == LogicalTypeId::INTEGER) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
-			                   ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
-			                   ScalarFunction::BinaryFunction<date_t, interval_t, date_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<date_t, interval_t, date_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::TIMESTAMP:
 		if (right_type.id() == LogicalTypeId::TIMESTAMP) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
-			                   ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
 		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::TIMESTAMP,
-			                   ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::INTERVAL:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
-			                   ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>));
+			                   ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
 		}
 		break;
 	case LogicalTypeId::TIME:
 		if (right_type.id() == LogicalTypeId::INTERVAL) {
-			return KeyFromArguments(
+			return
 			    ScalarFunction("-", {left_type, right_type}, LogicalType::TIME,
-			                   ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>));
+			                   ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>);
 		}
 		break;
 	default:

--- a/src/function/scalar/string/concat.cpp
+++ b/src/function/scalar/string/concat.cpp
@@ -254,7 +254,7 @@ void ConcatFun::RegisterFunction(BuiltinFunctions &set) {
 	concat_op.AddFunction(ScalarFunction({LogicalType::BLOB, LogicalType::BLOB}, LogicalType::BLOB, ConcatOperator));
 	concat_op.AddFunction(ListConcatFun::GetFunction());
 	for (auto &fun : concat_op.functions) {
-		fun.second.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+		fun.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 	}
 	set.AddFunction(concat_op);
 

--- a/src/function/scalar/string/prefix.cpp
+++ b/src/function/scalar/string/prefix.cpp
@@ -59,12 +59,10 @@ static bool PrefixFunction(const string_t &str, const string_t &pattern) {
 }
 
 ScalarFunction PrefixFun::GetFunction() {
-	auto function = ScalarFunction("prefix",                                     // name of the function
+	return ScalarFunction("prefix",                                     // name of the function
 	                      {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
 	                      LogicalType::BOOLEAN,                         // return type
 	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, PrefixOperator>);
-	function.function_set_key = 0;
-	return function;
 }
 
 void PrefixFun::RegisterFunction(BuiltinFunctions &set) {

--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -207,7 +207,7 @@ static unique_ptr<FunctionData> BindAggregateState(ClientContext &context, Scala
 	if (best_function == DConstants::INVALID_INDEX) {
 		throw InternalException("Could not re-bind exported aggregate %s: %s", state_type.function_name, error);
 	}
-	auto bound_aggr = aggr->functions.GetFunction(best_function);
+	auto bound_aggr = aggr->functions.GetFunctionByOffset(best_function);
 	if (bound_aggr.return_type != state_type.return_type || bound_aggr.arguments != state_type.bound_argument_types) {
 		throw InternalException("Type mismatch for exported aggregate %s", state_type.function_name);
 	}

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -406,7 +406,6 @@ TableFunction TableScanFunction::GetFunction() {
 	scan_function.filter_pushdown = true;
 	scan_function.serialize = TableScanSerialize;
 	scan_function.deserialize = TableScanDeserialize;
-	scan_function.function_set_key = 0;
 	return scan_function;
 }
 
@@ -420,7 +419,7 @@ TableCatalogEntry *TableScanFunction::GetTableEntry(const TableFunction &functio
 
 void TableScanFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet table_scan_set("seq_scan");
-	table_scan_set.AddFunction(GetFunction(), 0);
+	table_scan_set.AddFunction(GetFunction());
 	set.AddFunction(move(table_scan_set));
 }
 

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -61,6 +61,15 @@ public:
 	//! Join multiple strings into one string. Components are concatenated by the given separator
 	DUCKDB_API static string Join(const vector<string> &input, const string &separator);
 
+	template<class T>
+	static string ToString(const vector<T> &input, const string &separator) {
+		vector<string> input_list;
+		for(auto &i : input) {
+			input_list.push_back(i.ToString());
+		}
+		return StringUtil::Join(input_list, separator);
+	}
+
 	//! Join multiple items of container with given size, transformed to string
 	//! using function, into one string using the given separator
 	template <typename C, typename S, typename Func>

--- a/src/include/duckdb/common/string_util.hpp
+++ b/src/include/duckdb/common/string_util.hpp
@@ -61,10 +61,10 @@ public:
 	//! Join multiple strings into one string. Components are concatenated by the given separator
 	DUCKDB_API static string Join(const vector<string> &input, const string &separator);
 
-	template<class T>
+	template <class T>
 	static string ToString(const vector<T> &input, const string &separator) {
 		vector<string> input_list;
-		for(auto &i : input) {
+		for (auto &i : input) {
 			input_list.push_back(i.ToString());
 		}
 		return StringUtil::Join(input_list, separator);

--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -88,19 +88,19 @@ public:
 	//! Bind a scalar function from the set of functions and input arguments. Returns the index of the chosen function,
 	//! returns DConstants::INVALID_INDEX and sets error if none could be found
 	DUCKDB_API static idx_t BindFunction(const string &name, ScalarFunctionSet &functions,
-	                                     vector<LogicalType> &arguments, string &error);
+	                                     const vector<LogicalType> &arguments, string &error);
 	DUCKDB_API static idx_t BindFunction(const string &name, ScalarFunctionSet &functions,
 	                                     vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind an aggregate function from the set of functions and input arguments. Returns the index of the chosen
 	//! function, returns DConstants::INVALID_INDEX and sets error if none could be found
 	DUCKDB_API static idx_t BindFunction(const string &name, AggregateFunctionSet &functions,
-	                                     vector<LogicalType> &arguments, string &error);
+	                                     const vector<LogicalType> &arguments, string &error);
 	DUCKDB_API static idx_t BindFunction(const string &name, AggregateFunctionSet &functions,
 	                                     vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind a table function from the set of functions and input arguments. Returns the index of the chosen
 	//! function, returns DConstants::INVALID_INDEX and sets error if none could be found
 	DUCKDB_API static idx_t BindFunction(const string &name, TableFunctionSet &functions,
-	                                     vector<LogicalType> &arguments, string &error);
+	                                     const vector<LogicalType> &arguments, string &error);
 	DUCKDB_API static idx_t BindFunction(const string &name, TableFunctionSet &functions,
 	                                     vector<unique_ptr<Expression>> &arguments, string &error);
 	//! Bind a pragma function from the set of functions and input arguments
@@ -113,8 +113,6 @@ public:
 	DUCKDB_API SimpleFunction(string name, vector<LogicalType> arguments,
 	                          LogicalType varargs = LogicalType(LogicalTypeId::INVALID));
 	DUCKDB_API ~SimpleFunction() override;
-
-	idx_t function_set_key;
 
 	//! The set of arguments of the function
 	vector<LogicalType> arguments;

--- a/src/include/duckdb/function/function_set.hpp
+++ b/src/include/duckdb/function/function_set.hpp
@@ -47,7 +47,8 @@ public:
 		string error;
 		idx_t index = Function::BindFunction(name, *this, arguments, error);
 		if (index == DConstants::INVALID_INDEX) {
-			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","), error);
+			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
+			                        error);
 		}
 		return GetFunctionByOffset(index);
 	}
@@ -62,7 +63,8 @@ public:
 		string error;
 		idx_t index = Function::BindFunction(name, *this, arguments, error);
 		if (index == DConstants::INVALID_INDEX) {
-			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","), error);
+			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
+			                        error);
 		}
 		return GetFunctionByOffset(index);
 	}
@@ -77,7 +79,8 @@ public:
 		string error;
 		idx_t index = Function::BindFunction(name, *this, arguments, error);
 		if (index == DConstants::INVALID_INDEX) {
-			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","), error);
+			throw InternalException("Failed to find function %s(%s)\n%s", name, StringUtil::ToString(arguments, ","),
+			                        error);
 		}
 		return GetFunctionByOffset(index);
 	}

--- a/src/include/duckdb/parser/parsed_data/create_aggregate_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_aggregate_function_info.hpp
@@ -24,7 +24,7 @@ struct CreateAggregateFunctionInfo : public CreateFunctionInfo {
 	    : CreateFunctionInfo(CatalogType::AGGREGATE_FUNCTION_ENTRY), functions(move(set)) {
 		name = functions.name;
 		for (auto &func : functions.functions) {
-			func.second.name = functions.name;
+			func.name = functions.name;
 		}
 	}
 

--- a/src/include/duckdb/parser/parsed_data/create_scalar_function_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/create_scalar_function_info.hpp
@@ -24,7 +24,7 @@ struct CreateScalarFunctionInfo : public CreateFunctionInfo {
 	    : CreateFunctionInfo(CatalogType::SCALAR_FUNCTION_ENTRY), functions(move(set)) {
 		name = functions.name;
 		for (auto &func : functions.functions) {
-			func.second.name = functions.name;
+			func.name = functions.name;
 		}
 	}
 

--- a/src/include/duckdb/planner/expression/bound_parameter_expression.hpp
+++ b/src/include/duckdb/planner/expression/bound_parameter_expression.hpp
@@ -38,7 +38,6 @@ public:
 	unique_ptr<Expression> Copy() override;
 
 	void Serialize(FieldWriter &writer) const override;
-	static unique_ptr<Expression> Deserialize(ClientContext &context, ExpressionType type, FieldReader &reader);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/planner/operator/logical_comparison_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_comparison_join.hpp
@@ -31,6 +31,8 @@ public:
 	void Serialize(FieldWriter &writer) const override;
 	static unique_ptr<LogicalOperator> Deserialize(ClientContext &context, LogicalOperatorType type,
 	                                               FieldReader &reader);
+	static void Deserialize(LogicalComparisonJoin &comparison_join, ClientContext &context, LogicalOperatorType type,
+	                        FieldReader &reader);
 
 public:
 	static unique_ptr<LogicalOperator> CreateJoin(JoinType type, unique_ptr<LogicalOperator> left_child,

--- a/src/include/duckdb/planner/operator/logical_delim_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_delim_join.hpp
@@ -16,8 +16,7 @@ namespace duckdb {
 //! flattening, and involves performing duplicate elimination on the LEFT side which is then pushed into the RIGHT side.
 class LogicalDelimJoin : public LogicalComparisonJoin {
 public:
-	explicit LogicalDelimJoin(JoinType type) : LogicalComparisonJoin(type, LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-	}
+	explicit LogicalDelimJoin(JoinType type);
 
 	//! The set of columns that will be duplicate eliminated from the LHS and pushed into the RHS
 	vector<unique_ptr<Expression>> duplicate_eliminated_columns;

--- a/src/include/duckdb/planner/operator/logical_join.hpp
+++ b/src/include/duckdb/planner/operator/logical_join.hpp
@@ -38,8 +38,7 @@ public:
 public:
 	vector<ColumnBinding> GetColumnBindings() override;
 	void Serialize(FieldWriter &writer) const override;
-	static unique_ptr<LogicalOperator> Deserialize(ClientContext &context, LogicalOperatorType type,
-	                                               FieldReader &reader);
+	static void Deserialize(LogicalJoin &join, ClientContext &context, LogicalOperatorType type, FieldReader &reader);
 
 protected:
 	void ResolveTypes() override;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -148,7 +148,6 @@ unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan
 
 	Planner::VerifyPlan(context, plan);
 
-
 	return plan;
 }
 

--- a/src/optimizer/pullup/pullup_from_left.cpp
+++ b/src/optimizer/pullup/pullup_from_left.cpp
@@ -6,7 +6,8 @@ namespace duckdb {
 
 unique_ptr<LogicalOperator> FilterPullup::PullupFromLeft(unique_ptr<LogicalOperator> op) {
 	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
-	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT);
+	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT ||
+	         op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
 
 	FilterPullup left_pullup(true, can_add_column);
 	FilterPullup right_pullup(false, can_add_column);

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -14,11 +14,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 		return nullptr;
 	}
 	FunctionStatisticsInput input(func, func.bind_info.get(), stats, expr_ptr);
-	auto new_stats = func.function.statistics(context, input);
-	if (func.function.function_set_key == DConstants::INVALID_INDEX) {
-		throw BinderException("Function %s propagated to invalid set key", func.function.name);
-	}
-	return new_stats;
+	return func.function.statistics(context, input);
 }
 
 } // namespace duckdb

--- a/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -154,7 +154,7 @@ BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFuncti
 		throw BinderException(binder.FormatError(aggr, error));
 	}
 	// found a matching function!
-	auto bound_function = func->functions.GetFunction(best_function);
+	auto bound_function = func->functions.GetFunctionByOffset(best_function);
 
 	// Bind any sort columns, unless the aggregate is order-insensitive
 	auto order_bys = make_unique<BoundOrderModifier>();

--- a/src/planner/binder/expression/bind_window_expression.cpp
+++ b/src/planner/binder/expression/bind_window_expression.cpp
@@ -202,7 +202,7 @@ BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 			throw BinderException(binder.FormatError(window, error));
 		}
 		// found a matching function! bind it as an aggregate
-		auto bound_function = func->functions.GetFunction(best_function);
+		auto bound_function = func->functions.GetFunctionByOffset(best_function);
 		auto bound_aggregate = AggregateFunction::BindAggregateFunction(context, bound_function, move(children));
 		// create the aggregate
 		aggregate = make_unique<AggregateFunction>(bound_aggregate->function);

--- a/src/planner/binder/statement/bind_pragma.cpp
+++ b/src/planner/binder/statement/bind_pragma.cpp
@@ -15,7 +15,7 @@ BoundStatement Binder::Bind(PragmaStatement &stmt) {
 	if (bound_idx == DConstants::INVALID_INDEX) {
 		throw BinderException(FormatError(stmt.stmt_location, error));
 	}
-	auto bound_function = entry->functions.GetFunction(bound_idx);
+	auto bound_function = entry->functions.GetFunctionByOffset(bound_idx);
 	if (!bound_function.function) {
 		throw BinderException("PRAGMA function does not have a function specified");
 	}

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -217,7 +217,7 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 	if (best_function_idx == DConstants::INVALID_INDEX) {
 		throw BinderException(FormatError(ref, error));
 	}
-	auto table_function = function->functions.GetFunction(best_function_idx);
+	auto table_function = function->functions.GetFunctionByOffset(best_function_idx);
 
 	// now check the named parameters
 	BindNamedParameters(table_function.named_parameters, named_parameters, error_context, table_function.name);

--- a/src/planner/expression/bound_aggregate_expression.cpp
+++ b/src/planner/expression/bound_aggregate_expression.cpp
@@ -125,7 +125,6 @@ unique_ptr<Expression> BoundAggregateExpression::Deserialize(ClientContext &cont
 	function.return_type = return_type;
 	function.arguments = move(arguments);
 
-
 	auto has_bind_info = reader.ReadRequired<bool>();
 
 	if (has_bind_info) {

--- a/src/planner/expression/bound_conjunction_expression.cpp
+++ b/src/planner/expression/bound_conjunction_expression.cpp
@@ -44,7 +44,8 @@ void BoundConjunctionExpression::Serialize(FieldWriter &writer) const {
 	writer.WriteSerializableList(children);
 }
 
-unique_ptr<Expression> BoundConjunctionExpression::Deserialize(ClientContext &context, ExpressionType type, FieldReader &reader) {
+unique_ptr<Expression> BoundConjunctionExpression::Deserialize(ClientContext &context, ExpressionType type,
+                                                               FieldReader &reader) {
 	auto children = reader.ReadRequiredSerializableList<Expression>(context);
 	auto res = make_unique<BoundConjunctionExpression>(type);
 	res->children = move(children);

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -73,6 +73,7 @@ void BoundFunctionExpression::Verify() const {
 
 void BoundFunctionExpression::Serialize(FieldWriter &writer) const {
 	D_ASSERT(!function.name.empty());
+	D_ASSERT(return_type == function.return_type);
 	writer.WriteString(function.name);
 	writer.WriteField(is_operator);
 	writer.WriteSerializable(return_type);
@@ -80,9 +81,9 @@ void BoundFunctionExpression::Serialize(FieldWriter &writer) const {
 
 	writer.WriteSerializableList(children);
 
-	bool serialize_bind_info = bind_info && function.serialize;
-	writer.WriteField(serialize_bind_info);
-	if (serialize_bind_info) {
+	bool serialize = function.serialize;
+	writer.WriteField(serialize);
+	if (serialize) {
 		function.serialize(writer, bind_info.get(), function);
 	}
 }

--- a/src/planner/expression/bound_function_expression.cpp
+++ b/src/planner/expression/bound_function_expression.cpp
@@ -121,8 +121,9 @@ unique_ptr<Expression> BoundFunctionExpression::Deserialize(ClientContext &conte
 	} else if (function.bind) {
 		bind_info = function.bind(context, function, children);
 	}
+	return_type = function.return_type;
 
-	return make_unique<BoundFunctionExpression>(function.return_type, move(function), move(children), move(bind_info),
+	return make_unique<BoundFunctionExpression>(move(return_type), move(function), move(children), move(bind_info),
 	                                            is_operator);
 }
 } // namespace duckdb

--- a/src/planner/expression/bound_operator_expression.cpp
+++ b/src/planner/expression/bound_operator_expression.cpp
@@ -36,13 +36,18 @@ unique_ptr<Expression> BoundOperatorExpression::Copy() {
 void BoundOperatorExpression::Serialize(FieldWriter &writer) const {
 	writer.WriteField<ExpressionType>(type);
 	writer.WriteSerializable(return_type);
+	writer.WriteSerializableList(children);
 }
 
 unique_ptr<Expression> BoundOperatorExpression::Deserialize(ClientContext &context, ExpressionType type,
                                                             FieldReader &reader) {
 	auto expression_type = reader.ReadRequired<ExpressionType>();
 	auto return_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
-	return make_unique<BoundOperatorExpression>(expression_type, return_type);
+	auto children = reader.ReadRequiredSerializableList<Expression>(context);
+
+	auto result = make_unique<BoundOperatorExpression>(expression_type, return_type);
+	result->children = move(children);
+	return move(result);
 }
 
 } // namespace duckdb

--- a/src/planner/logical_operator.cpp
+++ b/src/planner/logical_operator.cpp
@@ -220,8 +220,7 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 		result = LogicalCTERef::Deserialize(context, type, reader);
 		break;
 	case LogicalOperatorType::LOGICAL_JOIN:
-		result = LogicalJoin::Deserialize(context, type, reader);
-		break;
+		throw InternalException("LogicalJoin deserialize not supported");
 	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
 		result = LogicalDelimJoin::Deserialize(context, type, reader);
 		break;

--- a/src/planner/operator/logical_column_data_get.cpp
+++ b/src/planner/operator/logical_column_data_get.cpp
@@ -4,9 +4,9 @@
 
 namespace duckdb {
 
-LogicalColumnDataGet::LogicalColumnDataGet(idx_t table_index, vector<LogicalType> types, unique_ptr<ColumnDataCollection> collection)
-	: LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index),
-	  collection(move(collection)) {
+LogicalColumnDataGet::LogicalColumnDataGet(idx_t table_index, vector<LogicalType> types,
+                                           unique_ptr<ColumnDataCollection> collection)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_CHUNK_GET), table_index(table_index), collection(move(collection)) {
 	D_ASSERT(types.size() > 0);
 	chunk_types = types;
 }
@@ -19,13 +19,13 @@ void LogicalColumnDataGet::Serialize(FieldWriter &writer) const {
 	writer.WriteField(table_index);
 	writer.WriteRegularSerializableList(chunk_types);
 	writer.WriteField(collection->ChunkCount());
-	for (auto& chunk : collection->Chunks()) {
+	for (auto &chunk : collection->Chunks()) {
 		chunk.Serialize(writer.GetSerializer());
 	}
 }
 
 unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(ClientContext &context, LogicalOperatorType type,
-                                                         FieldReader &reader) {
+                                                              FieldReader &reader) {
 	auto table_index = reader.ReadRequired<idx_t>();
 	auto chunk_types = reader.ReadRequiredSerializableList<LogicalType, LogicalType>();
 	auto chunk_count = reader.ReadRequired<idx_t>();
@@ -37,6 +37,5 @@ unique_ptr<LogicalOperator> LogicalColumnDataGet::Deserialize(ClientContext &con
 	}
 	return make_unique<LogicalColumnDataGet>(table_index, move(chunk_types), move(collection));
 }
-
 
 } // namespace duckdb

--- a/src/planner/operator/logical_delim_join.cpp
+++ b/src/planner/operator/logical_delim_join.cpp
@@ -3,21 +3,25 @@
 
 namespace duckdb {
 
+LogicalDelimJoin::LogicalDelimJoin(JoinType type)
+    : LogicalComparisonJoin(type, LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+}
+
 void LogicalDelimJoin::Serialize(FieldWriter &writer) const {
-	if (type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) { // DeliminatorPlanUpdater::VisitOperator can turn a
-		                                                        // delim join into a comparison join
-		return LogicalComparisonJoin::Serialize(writer);
+	LogicalComparisonJoin::Serialize(writer);
+	if (type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		D_ASSERT(duplicate_eliminated_columns.empty());
+		// if the delim join has no delim columns anymore it is turned into a regular comparison join
+		return;
 	}
-	writer.WriteField(join_type);
 	writer.WriteSerializableList(duplicate_eliminated_columns);
 }
 
 unique_ptr<LogicalOperator> LogicalDelimJoin::Deserialize(ClientContext &context, LogicalOperatorType type,
                                                           FieldReader &reader) {
-	auto join_type = reader.ReadRequired<JoinType>();
-	auto duplicate_eliminated_columns = reader.ReadRequiredSerializableList<Expression>(context);
-	auto result = make_unique<LogicalDelimJoin>(join_type);
-	result->duplicate_eliminated_columns = move(duplicate_eliminated_columns);
+	auto result = make_unique<LogicalDelimJoin>(JoinType::INVALID);
+	LogicalComparisonJoin::Deserialize(*result, context, type, reader);
+	result->duplicate_eliminated_columns = reader.ReadRequiredSerializableList<Expression>(context);
 	return result;
 }
 

--- a/src/planner/operator/logical_join.cpp
+++ b/src/planner/operator/logical_join.cpp
@@ -59,12 +59,33 @@ void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<idx_t> &
 }
 
 void LogicalJoin::Serialize(FieldWriter &writer) const {
-	throw NotImplementedException(LogicalOperatorToString(type));
+	writer.WriteField<JoinType>(join_type);
+	writer.WriteField<idx_t>(mark_index);
+	writer.WriteList<idx_t>(left_projection_map);
+	writer.WriteList<idx_t>(right_projection_map);
+	//	writer.WriteSerializableList(join_stats);
 }
 
-unique_ptr<LogicalOperator> LogicalJoin::Deserialize(ClientContext &context, LogicalOperatorType type,
-                                                     FieldReader &reader) {
-	throw NotImplementedException(LogicalOperatorToString(type));
+//
+//	//! The type of the join (INNER, OUTER, etc...)
+//	JoinType join_type;
+//	//! Table index used to refer to the MARK column (in case of a MARK join)
+//	idx_t mark_index;
+//	//! The columns of the LHS that are output by the join
+//	vector<idx_t> left_projection_map;
+//	//! The columns of the RHS that are output by the join
+//	vector<idx_t> right_projection_map;
+//	//! Join Keys statistics (optional)
+//	vector<unique_ptr<BaseStatistics>> join_stats;
+//
+
+void LogicalJoin::Deserialize(LogicalJoin &join, ClientContext &context, LogicalOperatorType type,
+                              FieldReader &reader) {
+	join.join_type = reader.ReadRequired<JoinType>();
+	join.mark_index = reader.ReadRequired<idx_t>();
+	join.left_projection_map = reader.ReadRequiredList<idx_t>();
+	join.right_projection_map = reader.ReadRequiredList<idx_t>();
+	//	join.join_stats = reader.ReadRequiredSerializableList<BaseStatistics>(reader.GetSource());
 }
 
 } // namespace duckdb

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -128,7 +128,7 @@ void Planner::VerifyPlan(ClientContext &context, unique_ptr<LogicalOperator> &op
 		return;
 	}
 	//! SELECT only for now
-	switch(op->type) {
+	switch (op->type) {
 	case LogicalOperatorType::LOGICAL_INSERT:
 	case LogicalOperatorType::LOGICAL_UPDATE:
 	case LogicalOperatorType::LOGICAL_DELETE:

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -58,7 +58,9 @@ void Planner::CreatePlan(SQLStatement &statement) {
 	this->properties.parameter_count = parameter_count;
 	properties.bound_all_parameters = parameters_resolved;
 
-	Planner::VerifyPlan(context, plan);
+	if (bound_parameters.parameters.empty()) {
+		Planner::VerifyPlan(context, plan);
+	}
 
 	// set up a map of parameter number -> value entries
 	for (auto &kv : bound_parameters.parameters) {

--- a/src/planner/pragma_handler.cpp
+++ b/src/planner/pragma_handler.cpp
@@ -67,7 +67,7 @@ string PragmaHandler::HandlePragma(SQLStatement *statement) { // PragmaInfo &inf
 	if (bound_idx == DConstants::INVALID_INDEX) {
 		throw BinderException(error);
 	}
-	auto bound_function = entry->functions.GetFunction(bound_idx);
+	auto bound_function = entry->functions.GetFunctionByOffset(bound_idx);
 	if (bound_function.query) {
 		QueryErrorContext error_context(statement, statement->stmt_location);
 		Binder::BindNamedParameters(bound_function.named_parameters, info.named_parameters, error_context,

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 if(${BUILD_TPCH_EXTENSION} AND NOT ${DISABLE_BUILTIN_EXTENSIONS})
   include_directories(../../extension/tpch/include)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_tpch_with_relations.cpp
-          test_tpch_plan_serialization.cpp)
+                       test_tpch_plan_serialization.cpp)
 endif()
 
 if(${BUILD_TPCDS_EXTENSION} AND NOT ${DISABLE_BUILTIN_EXTENSIONS})

--- a/test/api/test_tpcds_plan_serialization.cpp
+++ b/test/api/test_tpcds_plan_serialization.cpp
@@ -65,17 +65,18 @@ TEST_CASE("plan serialize tpcds", "[api]") {
 	tpcds_test_helper(con, 7);
 	tpcds_test_helper(con, 8);
 	tpcds_test_helper(con, 9);
-	//tpcds_test_helper(con, 10); // "right_bindings.find(table_binding) != right_bindings.end()"
+	// tpcds_test_helper(con, 10); // "right_bindings.find(table_binding) != right_bindings.end()"
 	tpcds_test_helper(con, 11);
-	//tpcds_test_helper(con, 12); // Failed to bind column reference
+	// tpcds_test_helper(con, 12); // Failed to bind column reference
 	tpcds_test_helper(con, 13);
 	tpcds_test_helper(con, 14);
-	//tpcds_test_helper(con, 15); // "right_bindings.find(table_binding) != right_bindings.end()"
-	//tpcds_test_helper(con, 16); // "op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT"
-	//tpcds_test_helper(con, 17); // Invalid function serialization key
-	//tpcds_test_helper(con, 18); // "right_bindings.find(table_binding) != right_bindings.end()"
+	// tpcds_test_helper(con, 15); // "right_bindings.find(table_binding) != right_bindings.end()"
+	// tpcds_test_helper(con, 16); // "op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op->type ==
+	// LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT" tpcds_test_helper(con,
+	// 17); // Invalid function serialization key tpcds_test_helper(con, 18); // "right_bindings.find(table_binding) !=
+	// right_bindings.end()"
 	tpcds_test_helper(con, 19);
-	//tpcds_test_helper(con, 20); // Failed to bind column reference
+	// tpcds_test_helper(con, 20); // Failed to bind column reference
 
 	// TODO(stephwang): below tests have not been run yet
 	tpcds_test_helper(con, 21);

--- a/test/api/test_tpch_plan_serialization.cpp
+++ b/test/api/test_tpch_plan_serialization.cpp
@@ -46,7 +46,7 @@ static void tpch_test_helper(Connection &con, idx_t q) {
 	auto statement = make_unique<LogicalPlanStatement>(move(new_plan));
 	auto result = con.Query(move(statement));
 	REQUIRE(result->success);
-	//COMPARE_CSV(result, TPCHExtension::GetAnswer(0.01, q), true);
+	// COMPARE_CSV(result, TPCHExtension::GetAnswer(0.01, q), true);
 
 	con.Rollback();
 }

--- a/test/api/test_tpch_plan_serialization.cpp
+++ b/test/api/test_tpch_plan_serialization.cpp
@@ -45,7 +45,10 @@ static void tpch_test_helper(Connection &con, idx_t q) {
 
 	auto statement = make_unique<LogicalPlanStatement>(move(new_plan));
 	auto result = con.Query(move(statement));
-	REQUIRE(result->success);
+	if (!result->success) {
+		printf("%s\n", result->error.c_str());
+		REQUIRE(result->success);
+	}
 	// COMPARE_CSV(result, TPCHExtension::GetAnswer(0.01, q), true);
 
 	con.Rollback();
@@ -57,25 +60,25 @@ TEST_CASE("plan serialize tpch", "[api]") {
 	// con.EnableQueryVerification(); // can't because LogicalPlanStatement can't be copied
 	con.Query("CALL dbgen(sf=0.01)");
 	tpch_test_helper(con, 1);
-	// tpch_test_helper(con, 2); // Invalid function serialization key
+	tpch_test_helper(con, 2);
 	tpch_test_helper(con, 3);
 	tpch_test_helper(con, 4);
 	tpch_test_helper(con, 5);
 	tpch_test_helper(con, 6);
 	tpch_test_helper(con, 7);
 	tpch_test_helper(con, 8);
-	// tpch_test_helper(con, 9); // Invalid function serialization key
+	tpch_test_helper(con, 9);
 	tpch_test_helper(con, 10);
 	tpch_test_helper(con, 11);
 	tpch_test_helper(con, 12);
-	// tpch_test_helper(con, 13); // Have bind info but no serialization function
+	tpch_test_helper(con, 13);
 	tpch_test_helper(con, 14);
 	tpch_test_helper(con, 15);
-	// tpch_test_helper(con, 16); // Have bind info but no serialization function
+	tpch_test_helper(con, 16);
 	tpch_test_helper(con, 17);
 	tpch_test_helper(con, 18);
 	tpch_test_helper(con, 19);
 	tpch_test_helper(con, 20);
-	// tpch_test_helper(con, 21); // assertion error related to prepared statement
-	// tpch_test_helper(con, 22); // assertion error related to prepared statement
+	tpch_test_helper(con, 21);
+	tpch_test_helper(con, 22);
 }

--- a/test/sql/types/decimal/decimal_arithmetic.test
+++ b/test/sql/types/decimal/decimal_arithmetic.test
@@ -108,6 +108,12 @@ CREATE TABLE decimals(d DECIMAL(3, 2));
 statement ok
 INSERT INTO decimals VALUES ('0.1'), ('0.2');
 
+query I
+SELECT d + 10000 FROM decimals;
+----
+10000.1
+10000.2
+
 query II
 SELECT d + '0.1'::DECIMAL, d + 10000 FROM decimals;
 ----


### PR DESCRIPTION
This simplifies the serialization in a lot of cases, and avoids potential issues when dealing with loading extensions (as loading extensions in different orders might result in different `function_set_key` values). 

In addition, to avoid always requiring a `serialize/deserialize` pair we default to re-binding the function using the input arguments. This does not always work (e.g. certain decimal functions still require the `serialize/deserialize` function) but it works often enough that it is a sane default.

All TPC-H queries now (de)serialize without errors after this PR.